### PR TITLE
Make getMemberList() work on lists with few subscribers

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -49,13 +49,18 @@ class MailmanAPI {
 		// Get all the urs for the letters
 		$letterLinks = $trs[1];
 		$links = $letterLinks->getElementsByTagName("a");
+
+		$memberList = array();
+
+		if (count($links) === 0) {
+			return $this->getMembersFromTableRows($trs, $isSinglePage = true);
+		}
+
 		$urlsForLetters = array();
 
 		foreach($links as $link) {
 			$urlsForLetters[] =  $link->getAttribute('href');
 		}
-
-		$memberList = array();
 
 		foreach($urlsForLetters as $url) {
 			$response = $this->client->request('GET', $url);
@@ -66,11 +71,32 @@ class MailmanAPI {
 			$tables = $dom->getElementsByTagName("table")[4];
 			$trs = $tables->getElementsByTagName("tr");
 
-			for ($i = 3 ; $i < $trs->length; $i++) {
-				$tds = $trs[$i]->getElementsByTagName("td");
-				$memberList[] = $tds[1]->nodeValue;
-			}
+			$memberList = array_merge(
+				$memberList,
+				$this->getMembersFromTableRows($trs)
+			);
+		}
 
+		return $memberList;
+	}
+
+	/**
+	 * Get the e-mail addresses from a list of table rows (<tr>).
+	 *
+	 * @param  DOMNodeList  $trs
+	 * @param  bool    	$isSinglePage
+	 *
+	 * @return array
+	 */
+	protected function getMembersFromTableRows($trs, $isSinglePage = false)
+	{
+		$firstRowIndex = $isSinglePage ? 2 : 3;
+
+		$memberList = [];
+
+		for ($i = $firstRowIndex; $i < $trs->length; $i++) {
+			$tds = $trs[$i]->getElementsByTagName("td");
+			$memberList[] = $tds[1]->nodeValue;
 		}
 
 		return $memberList;


### PR DESCRIPTION
Hi @splattner !

Nice to see someone trying to solve the same obscure problems as me. It seems the world of PHP packages just doesn’t care about good old Mailman lists 😄

### Issue and fix

Your code currently works well on most lists, but it fails if the Mailman instance has just a small number of subscribers. In these cases, Mailman lists everybody on the same page, without displaying any ‘letter links’.

So this pull requests aims at fixing this. If it detects that all subscribers are on the page we’re already in, it will simply parse the table rows there, without making any additional HTTP request.

I successfully tested these changes with a list with __17__ subscribers (all on the same page) and with a list having __48__ subscribers (spread on multiple pages) to ensure I did not break anything.

---

I’m wondering if you would be interested to turn this project into a more complete API (with refactored code and additional features such as, for example, retrieving the names of subscribers, or allowing to manage some of their settings), or are you happy with it as it is right now?

I’m currently working on a website that, among other things, needs to manage several external Mailman lists by adding the site members as subscribers to the lists. I’ve been thinking of building an open source PHP package for that, but I could also be happy to contribute to an existing one if you’re open to it.