### PR TITLE
Ignore warnings about bad html

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -65,8 +65,15 @@ class MailmanAPI {
 		foreach($urlsForLetters as $url) {
 			$response = $this->client->request('GET', $url);
 
-			$dom = new \DOMDocument;
-			$dom->loadHTML($response->getBody());
+			$dom = new \DOMDocument('1.0', 'UTF-8');
+
+            // set error level
+            $internalErrors = libxml_use_internal_errors(true);
+
+            $dom->loadHTML($response->getBody());
+
+            // Restore error level
+            libxml_use_internal_errors($internalErrors);
 
 			$tables = $dom->getElementsByTagName("table")[4];
 			$trs = $tables->getElementsByTagName("tr");

--- a/src/api.php
+++ b/src/api.php
@@ -67,13 +67,13 @@ class MailmanAPI {
 
 			$dom = new \DOMDocument('1.0', 'UTF-8');
 
-            // set error level
-            $internalErrors = libxml_use_internal_errors(true);
+			// set error level
+			$internalErrors = libxml_use_internal_errors(true);
 
-            $dom->loadHTML($response->getBody());
+			$dom->loadHTML($response->getBody());
 
-            // Restore error level
-            libxml_use_internal_errors($internalErrors);
+			// Restore error level
+			libxml_use_internal_errors($internalErrors);
 
 			$tables = $dom->getElementsByTagName("table")[4];
 			$trs = $tables->getElementsByTagName("tr");


### PR DESCRIPTION
In some mailman pages, this lib is not working with following error message:

`Warning: DOMDocument::loadHTML(): htmlParseEntityRef: expecting ';' in Entity,`

The solution was based on:

https://stackoverflow.com/questions/1685277/warning-domdocumentloadhtml-htmlparseentityref-expecting-in-entity